### PR TITLE
Use the same host iterator in speculative execution

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -304,7 +304,8 @@ type HostSelectionPolicy interface {
 	KeyspaceChanged(KeyspaceUpdateEvent)
 	Init(*Session)
 	IsLocal(host *HostInfo) bool
-	//Pick returns an iteration function over selected hosts
+	// Pick returns an iteration function over selected hosts.
+	// The returned NextHost function won't be called concurrently by the driver.
 	Pick(ExecutableQuery) NextHost
 }
 

--- a/query_executor.go
+++ b/query_executor.go
@@ -2,6 +2,7 @@ package gocql
 
 import (
 	"context"
+	"sync"
 	"time"
 )
 
@@ -36,14 +37,15 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry ExecutableQuery, c
 	return iter
 }
 
-func (q *queryExecutor) speculate(ctx context.Context, qry ExecutableQuery, sp SpeculativeExecutionPolicy, results chan *Iter) *Iter {
+func (q *queryExecutor) speculate(ctx context.Context, qry ExecutableQuery, sp SpeculativeExecutionPolicy,
+	hostIter NextHost, results chan *Iter) *Iter {
 	ticker := time.NewTicker(sp.Delay())
 	defer ticker.Stop()
 
 	for i := 0; i < sp.Attempts(); i++ {
 		select {
 		case <-ticker.C:
-			go q.run(ctx, qry, results)
+			go q.run(ctx, qry, hostIter, results)
 		case <-ctx.Done():
 			return &Iter{err: ctx.Err()}
 		case iter := <-results:
@@ -55,11 +57,23 @@ func (q *queryExecutor) speculate(ctx context.Context, qry ExecutableQuery, sp S
 }
 
 func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
+	hostIter := q.policy.Pick(qry)
+
 	// check if the query is not marked as idempotent, if
 	// it is, we force the policy to NonSpeculative
 	sp := qry.speculativeExecutionPolicy()
 	if !qry.IsIdempotent() || sp.Attempts() == 0 {
-		return q.do(qry.Context(), qry), nil
+		return q.do(qry.Context(), qry, hostIter), nil
+	}
+
+	// When speculative execution is enabled, we could be accessing the host iterator from multiple goroutines below.
+	// To ensure we don't call it concurrently, we wrap the returned NextHost function here to synchronize access to it.
+	var mu sync.Mutex
+	origHostIter := hostIter
+	hostIter = func() SelectedHost {
+		mu.Lock()
+		defer mu.Unlock()
+		return origHostIter()
 	}
 
 	ctx, cancel := context.WithCancel(qry.Context())
@@ -68,12 +82,12 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 	results := make(chan *Iter, 1)
 
 	// Launch the main execution
-	go q.run(ctx, qry, results)
+	go q.run(ctx, qry, hostIter, results)
 
 	// The speculative executions are launched _in addition_ to the main
 	// execution, on a timer. So Speculation{2} would make 3 executions running
 	// in total.
-	if iter := q.speculate(ctx, qry, sp, results); iter != nil {
+	if iter := q.speculate(ctx, qry, sp, hostIter, results); iter != nil {
 		return iter, nil
 	}
 
@@ -85,8 +99,7 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 	}
 }
 
-func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery) *Iter {
-	hostIter := q.policy.Pick(qry)
+func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter NextHost) *Iter {
 	selectedHost := hostIter()
 	rt := qry.retryPolicy()
 
@@ -155,9 +168,9 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery) *Iter {
 	return &Iter{err: ErrNoConnections}
 }
 
-func (q *queryExecutor) run(ctx context.Context, qry ExecutableQuery, results chan<- *Iter) {
+func (q *queryExecutor) run(ctx context.Context, qry ExecutableQuery, hostIter NextHost, results chan<- *Iter) {
 	select {
-	case results <- q.do(ctx, qry):
+	case results <- q.do(ctx, qry, hostIter):
 	case <-ctx.Done():
 	}
 }


### PR DESCRIPTION
Before this commit, regular query execution path and speculative
execution path did not use the same host iterator.
This means that speculative execution could retry on the same
host as the original attempt. This could lead to overloading that
slow host even more instead of trying on some other host if
the policy consistently selects that host (for example based on
token).

We fix this by sharing the host iterator returned by the host selection
policy. The returned iterator could now accessed from multiple
goroutines, so we need to synchronize access to it. I chose this instead
of implementing synchronization in each policy because I can't fix
any user-provided policies. Synchronizing in the driver avoids
introducing new data race for user-provided policies as those likely
won't be updated.

Fixes https://github.com/gocql/gocql/issues/1530