### PR TITLE
Fix build

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1092,6 +1092,7 @@ type TestServer struct {
 	t                testing.TB
 	listen           net.Listener
 	nKillReq         int64
+	supportedFactory testSupportedFactory
 
 	protocol   byte
 	headerSize int
@@ -1103,6 +1104,20 @@ type TestServer struct {
 
 	// onRecv is a hook point for tests, called in receive loop.
 	onRecv func(*framer)
+}
+
+type testSupportedFactory func(conn net.Conn) map[string][]string
+
+func (srv *TestServer) session() (*Session, error) {
+	return testCluster(protoVersion(srv.protocol), srv.Address).CreateSession()
+}
+
+func (srv *TestServer) host() *HostInfo {
+	hosts, err := hostInfo(srv.Address, 9042)
+	if err != nil {
+		srv.t.Fatal(err)
+	}
+	return hosts[0]
 }
 
 func (srv *TestServer) closeWatch() {


### PR DESCRIPTION
The tests broke because of bad conflict resolution in
a41eaadc9efef43f94d8ce7eb0b4411d19a799bf.