### PR TITLE
Don't reset connection on non-write errors

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -2129,7 +2129,7 @@ func TestNegativeStream(t *testing.T) {
 	const stream = -50
 	writer := frameWriterFunc(func(f *framer, streamID int) error {
 		f.writeHeader(0, opOptions, stream)
-		return f.finishWrite()
+		return f.finish()
 	})
 
 	frame, err := conn.exec(context.Background(), writer, nil)

--- a/conn.go
+++ b/conn.go
@@ -410,7 +410,7 @@ func (s *startupCoordinator) setupConn(ctx context.Context) error {
 	return nil
 }
 
-func (s *startupCoordinator) write(ctx context.Context, frame frameWriter) (frame, error) {
+func (s *startupCoordinator) write(ctx context.Context, frame frameBuilder) (frame, error) {
 	select {
 	case s.frameTicker <- struct{}{}:
 	case <-ctx.Done():
@@ -697,8 +697,8 @@ func (c *Conn) recv(ctx context.Context) error {
 		return fmt.Errorf("gocql: frame header stream is beyond call expected bounds: %d", head.stream)
 	} else if head.stream == -1 {
 		// TODO: handle cassandra event frames, we shouldnt get any currently
-		framer := newFramerWithExts(c, c, c.compressor, c.version, c.cqlProtoExts)
-		if err := framer.readFrame(&head); err != nil {
+		framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts)
+		if err := framer.readFrame(c, &head); err != nil {
 			return err
 		}
 		go c.session.handleEvent(framer)
@@ -706,8 +706,8 @@ func (c *Conn) recv(ctx context.Context) error {
 	} else if head.stream <= 0 {
 		// reserved stream that we dont use, probably due to a protocol error
 		// or a bug in Cassandra, this should be an error, parse it and return.
-		framer := newFramerWithExts(c, c, c.compressor, c.version, c.cqlProtoExts)
-		if err := framer.readFrame(&head); err != nil {
+		framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts)
+		if err := framer.readFrame(c, &head); err != nil {
 			return err
 		}
 
@@ -732,7 +732,7 @@ func (c *Conn) recv(ctx context.Context) error {
 		panic(fmt.Sprintf("call has incorrect streamID: got %d expected %d", call.streamID, head.stream))
 	}
 
-	err = call.framer.readFrame(&head)
+	err = call.framer.readFrame(c, &head)
 	if err != nil {
 		// only net errors should cause the connection to be closed. Though
 		// cassandra returning corrupt frames will be returned here as well.
@@ -928,7 +928,7 @@ func (w *writeCoalescer) writeFlusher(interval time.Duration) {
 	}
 }
 
-func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*framer, error) {
+func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*framer, error) {
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
 	}
@@ -940,7 +940,7 @@ func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*frame
 	}
 
 	// resp is basically a waiting semaphore protecting the framer
-	framer := newFramerWithExts(c, c, c.compressor, c.version, c.cqlProtoExts)
+	framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts)
 
 	call := &callReq{
 		framer:   framer,
@@ -974,7 +974,15 @@ func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*frame
 		})
 	}
 
-	err := req.writeFrame(framer, stream)
+	err := req.buildFrame(framer, stream)
+	if err != nil {
+		// We failed to serialize the frame into a buffer.
+		// This should not affect the connection, we just free the current call.
+		c.releaseStream(call)
+		return nil, err
+	}
+
+	err = framer.writeTo(c)
 	if err != nil {
 		// closeWithError will block waiting for this stream to either receive a response
 		// or for us to timeout, close the timeout chan here. Im not entirely sure
@@ -1226,7 +1234,7 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 	}
 
 	var (
-		frame frameWriter
+		frame frameBuilder
 		info  *preparedStatment
 	)
 

--- a/control.go
+++ b/control.go
@@ -401,7 +401,7 @@ func (c *controlConn) getConn() *connHost {
 	return c.conn.Load().(*connHost)
 }
 
-func (c *controlConn) writeFrame(w frameWriter) (frame, error) {
+func (c *controlConn) writeFrame(w frameBuilder) (frame, error) {
 	ch := c.getConn()
 	if ch == nil {
 		return nil, errNoControl

--- a/frame.go
+++ b/frame.go
@@ -346,9 +346,6 @@ type FrameHeaderObserver interface {
 
 // a framer is responsible for reading, writing and parsing frames on a single stream
 type framer struct {
-	r io.Reader
-	w io.Writer
-
 	proto byte
 	// flags are for outgoing flags, enabling compression and tracing etc
 	flags    byte
@@ -372,7 +369,7 @@ type framer struct {
 	flagLWT int
 }
 
-func newFramer(r io.Reader, w io.Writer, compressor Compressor, version byte) *framer {
+func newFramer(compressor Compressor, version byte) *framer {
 	f := &framer{
 		wbuf:       make([]byte, defaultBufSize),
 		readBuffer: make([]byte, defaultBufSize),
@@ -397,10 +394,8 @@ func newFramer(r io.Reader, w io.Writer, compressor Compressor, version byte) *f
 	f.flags = flags
 	f.headSize = headSize
 
-	f.r = r
 	f.rbuf = f.readBuffer[:0]
 
-	f.w = w
 	f.wbuf = f.wbuf[:0]
 
 	f.header = nil
@@ -409,10 +404,9 @@ func newFramer(r io.Reader, w io.Writer, compressor Compressor, version byte) *f
 	return f
 }
 
-func newFramerWithExts(r io.Reader, w io.Writer, compressor Compressor, version byte,
-	cqlProtoExts []cqlProtocolExtension) *framer {
+func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlProtocolExtension) *framer {
 
-	f := newFramer(r, w, compressor, version)
+	f := newFramer(compressor, version)
 
 	if lwtExt := findCQLProtoExtByName(cqlProtoExts, lwtAddMetadataMarkKey); lwtExt != nil {
 		castedExt, ok := lwtExt.(*lwtAddMetadataMarkExt)
@@ -491,12 +485,12 @@ func (f *framer) payload() {
 }
 
 // reads a frame form the wire into the framers buffer
-func (f *framer) readFrame(head *frameHeader) error {
+func (f *framer) readFrame(r io.Reader, head *frameHeader) error {
 	if head.length < 0 {
 		return fmt.Errorf("frame body length can not be less than 0: %d", head.length)
 	} else if head.length > maxFrameSize {
 		// need to free up the connection to be used again
-		_, err := io.CopyN(ioutil.Discard, f.r, int64(head.length))
+		_, err := io.CopyN(ioutil.Discard, r, int64(head.length))
 		if err != nil {
 			return fmt.Errorf("error whilst trying to discard frame with invalid length: %v", err)
 		}
@@ -511,7 +505,7 @@ func (f *framer) readFrame(head *frameHeader) error {
 	}
 
 	// assume the underlying reader takes care of timeouts and retries
-	n, err := io.ReadFull(f.r, f.rbuf)
+	n, err := io.ReadFull(r, f.rbuf)
 	if err != nil {
 		return fmt.Errorf("unable to read frame body: read %d/%d bytes: %v", n, head.length, err)
 	}
@@ -746,7 +740,7 @@ func (f *framer) setLength(length int) {
 	f.wbuf[p+3] = byte(length)
 }
 
-func (f *framer) finishWrite() error {
+func (f *framer) finish() error {
 	if len(f.wbuf) > maxFrameSize {
 		// huge app frame, lets remove it so it doesn't bloat the heap
 		f.wbuf = make([]byte, defaultBufSize)
@@ -769,12 +763,12 @@ func (f *framer) finishWrite() error {
 	length := len(f.wbuf) - f.headSize
 	f.setLength(length)
 
-	_, err := f.w.Write(f.wbuf)
-	if err != nil {
-		return err
-	}
-
 	return nil
+}
+
+func (f *framer) writeTo(w io.Writer) error {
+	_, err := w.Write(f.wbuf)
+	return err
 }
 
 func (f *framer) readTrace() {
@@ -815,11 +809,11 @@ func (w writeStartupFrame) String() string {
 	return fmt.Sprintf("[startup opts=%+v]", w.opts)
 }
 
-func (w *writeStartupFrame) writeFrame(f *framer, streamID int) error {
+func (w *writeStartupFrame) buildFrame(f *framer, streamID int) error {
 	f.writeHeader(f.flags&^flagCompress, opStartup, streamID)
 	f.writeStringMap(w.opts)
 
-	return f.finishWrite()
+	return f.finish()
 }
 
 type writePrepareFrame struct {
@@ -828,7 +822,7 @@ type writePrepareFrame struct {
 	customPayload map[string][]byte
 }
 
-func (w *writePrepareFrame) writeFrame(f *framer, streamID int) error {
+func (w *writePrepareFrame) buildFrame(f *framer, streamID int) error {
 	if len(w.customPayload) > 0 {
 		f.payload()
 	}
@@ -851,7 +845,7 @@ func (w *writePrepareFrame) writeFrame(f *framer, streamID int) error {
 		f.writeString(w.keyspace)
 	}
 
-	return f.finishWrite()
+	return f.finish()
 }
 
 func (f *framer) readTypeInfo() TypeInfo {
@@ -1415,14 +1409,14 @@ func (a *writeAuthResponseFrame) String() string {
 	return fmt.Sprintf("[auth_response data=%q]", a.data)
 }
 
-func (a *writeAuthResponseFrame) writeFrame(framer *framer, streamID int) error {
+func (a *writeAuthResponseFrame) buildFrame(framer *framer, streamID int) error {
 	return framer.writeAuthResponseFrame(streamID, a.data)
 }
 
 func (f *framer) writeAuthResponseFrame(streamID int, data []byte) error {
 	f.writeHeader(f.flags, opAuthResponse, streamID)
 	f.writeBytes(data)
-	return f.finishWrite()
+	return f.finish()
 }
 
 type queryValues struct {
@@ -1560,7 +1554,7 @@ func (w *writeQueryFrame) String() string {
 	return fmt.Sprintf("[query statement=%q params=%v]", w.statement, w.params)
 }
 
-func (w *writeQueryFrame) writeFrame(framer *framer, streamID int) error {
+func (w *writeQueryFrame) buildFrame(framer *framer, streamID int) error {
 	return framer.writeQueryFrame(streamID, w.statement, &w.params, w.customPayload)
 }
 
@@ -1573,16 +1567,16 @@ func (f *framer) writeQueryFrame(streamID int, statement string, params *queryPa
 	f.writeLongString(statement)
 	f.writeQueryParams(params)
 
-	return f.finishWrite()
+	return f.finish()
 }
 
-type frameWriter interface {
-	writeFrame(framer *framer, streamID int) error
+type frameBuilder interface {
+	buildFrame(framer *framer, streamID int) error
 }
 
 type frameWriterFunc func(framer *framer, streamID int) error
 
-func (f frameWriterFunc) writeFrame(framer *framer, streamID int) error {
+func (f frameWriterFunc) buildFrame(framer *framer, streamID int) error {
 	return f(framer, streamID)
 }
 
@@ -1598,7 +1592,7 @@ func (e *writeExecuteFrame) String() string {
 	return fmt.Sprintf("[execute id=% X params=%v]", e.preparedID, &e.params)
 }
 
-func (e *writeExecuteFrame) writeFrame(fr *framer, streamID int) error {
+func (e *writeExecuteFrame) buildFrame(fr *framer, streamID int) error {
 	return fr.writeExecuteFrame(streamID, e.preparedID, &e.params, &e.customPayload)
 }
 
@@ -1624,7 +1618,7 @@ func (f *framer) writeExecuteFrame(streamID int, preparedID []byte, params *quer
 		f.writeConsistency(params.consistency)
 	}
 
-	return f.finishWrite()
+	return f.finish()
 }
 
 // TODO: can we replace BatchStatemt with batchStatement? As they prety much
@@ -1649,7 +1643,7 @@ type writeBatchFrame struct {
 	customPayload map[string][]byte
 }
 
-func (w *writeBatchFrame) writeFrame(framer *framer, streamID int) error {
+func (w *writeBatchFrame) buildFrame(framer *framer, streamID int) error {
 	return framer.writeBatchFrame(streamID, w, w.customPayload)
 }
 
@@ -1727,25 +1721,25 @@ func (f *framer) writeBatchFrame(streamID int, w *writeBatchFrame, customPayload
 		}
 	}
 
-	return f.finishWrite()
+	return f.finish()
 }
 
 type writeOptionsFrame struct{}
 
-func (w *writeOptionsFrame) writeFrame(framer *framer, streamID int) error {
+func (w *writeOptionsFrame) buildFrame(framer *framer, streamID int) error {
 	return framer.writeOptionsFrame(streamID, w)
 }
 
 func (f *framer) writeOptionsFrame(stream int, _ *writeOptionsFrame) error {
 	f.writeHeader(f.flags&^flagCompress, opOptions, stream)
-	return f.finishWrite()
+	return f.finish()
 }
 
 type writeRegisterFrame struct {
 	events []string
 }
 
-func (w *writeRegisterFrame) writeFrame(framer *framer, streamID int) error {
+func (w *writeRegisterFrame) buildFrame(framer *framer, streamID int) error {
 	return framer.writeRegisterFrame(streamID, w)
 }
 
@@ -1753,7 +1747,7 @@ func (f *framer) writeRegisterFrame(streamID int, w *writeRegisterFrame) error {
 	f.writeHeader(f.flags, opRegister, streamID)
 	f.writeStringList(w.events)
 
-	return f.finishWrite()
+	return f.finish()
 }
 
 func (f *framer) readByte() byte {

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -194,7 +194,7 @@ func TestScyllaLWTExtParsing(t *testing.T) {
 		// mock connection without cql extensions, expected not to have
 		// the `flagLWT` field being set in the framer created out of it
 		conn := mockConn(0)
-		f := newFramerWithExts(conn, conn, conn.compressor, conn.version, conn.cqlProtoExts)
+		f := newFramerWithExts(conn.compressor, conn.version, conn.cqlProtoExts)
 		if f.flagLWT != 0 {
 			t.Error("expected to have LWT flag uninitialized after framer init")
 		}
@@ -210,7 +210,7 @@ func TestScyllaLWTExtParsing(t *testing.T) {
 				lwtOptMetaBitMask: 1,
 			},
 		}
-		framerWithLwtExt := newFramerWithExts(conn, conn, conn.compressor, conn.version, conn.cqlProtoExts)
+		framerWithLwtExt := newFramerWithExts(conn.compressor, conn.version, conn.cqlProtoExts)
 		if framerWithLwtExt.flagLWT == 0 {
 			t.Error("expected to have LWT flag to be set after framer init")
 		}


### PR DESCRIPTION
If there is an error like too big frame that we are sending,
we don't want to close the connection as we abort before trying
to write there. We don't clobber the data stream in this case.

As framer is basically a buffer of frame data,
I moved the I/O operations to separate methods with
explicit reader/writer arguments so that we can
distinguish when IO fails.