### PR TITLE
Add per-session logger

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -167,6 +167,10 @@ type ClusterConfig struct {
 	// your network nor disable shard-aware port on your nodes.
 	DisableShardAwarePort bool
 
+	// Logger for this ClusterConfig.
+	// If not specified, defaults to the global gocql.Logger.
+	Logger StdLogger
+
 	// internal config for testing
 	disableControlConn bool
 }
@@ -206,6 +210,13 @@ func NewCluster(hosts ...string) *ClusterConfig {
 	return cfg
 }
 
+func (cfg *ClusterConfig) logger() StdLogger {
+	if cfg.Logger == nil {
+		return Logger
+	}
+	return cfg.Logger
+}
+
 // CreateSession initializes the cluster based on this config and returns a
 // session object that can be used to interact with the database.
 func (cfg *ClusterConfig) CreateSession() (*Session, error) {
@@ -222,7 +233,7 @@ func (cfg *ClusterConfig) translateAddressPort(addr net.IP, port int) (net.IP, i
 	}
 	newAddr, newPort := cfg.AddressTranslator.Translate(addr, port)
 	if gocqlDebug {
-		Logger.Printf("gocql: translating address '%v:%d' to '%v:%d'", addr, port, newAddr, newPort)
+		cfg.logger().Printf("gocql: translating address '%v:%d' to '%v:%d'", addr, port, newAddr, newPort)
 	}
 	return newAddr, newPort
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -151,10 +151,6 @@ func newTestSession(proto protoVersion, addresses ...string) (*Session, error) {
 
 func TestDNSLookupConnected(t *testing.T) {
 	log := &testLogger{}
-	Logger = log
-	defer func() {
-		Logger = &defaultLogger{}
-	}()
 
 	// Override the defaul DNS resolver and restore at the end
 	failDNS = true
@@ -164,6 +160,7 @@ func TestDNSLookupConnected(t *testing.T) {
 	defer srv.Stop()
 
 	cluster := NewCluster("cassandra1.invalid", srv.Address, "cassandra2.invalid")
+	cluster.Logger = log
 	cluster.ProtoVersion = int(defaultProto)
 	cluster.disableControlConn = true
 
@@ -181,16 +178,13 @@ func TestDNSLookupConnected(t *testing.T) {
 
 func TestDNSLookupError(t *testing.T) {
 	log := &testLogger{}
-	Logger = log
-	defer func() {
-		Logger = &defaultLogger{}
-	}()
 
 	// Override the defaul DNS resolver and restore at the end
 	failDNS = true
 	defer func() { failDNS = false }()
 
 	cluster := NewCluster("cassandra1.invalid", "cassandra2.invalid")
+	cluster.Logger = log
 	cluster.ProtoVersion = int(defaultProto)
 	cluster.disableControlConn = true
 
@@ -213,10 +207,6 @@ func TestDNSLookupError(t *testing.T) {
 func TestStartupTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	log := &testLogger{}
-	Logger = log
-	defer func() {
-		Logger = &defaultLogger{}
-	}()
 
 	srv := NewTestServer(t, defaultProto, ctx)
 	defer srv.Stop()
@@ -226,6 +216,7 @@ func TestStartupTimeout(t *testing.T) {
 
 	startTime := time.Now()
 	cluster := NewCluster(srv.Address)
+	cluster.Logger = log
 	cluster.ProtoVersion = int(defaultProto)
 	cluster.disableControlConn = true
 	// Set very long query connection timeout
@@ -323,13 +314,14 @@ func TestCancel(t *testing.T) {
 type testQueryObserver struct {
 	metrics map[string]*hostMetrics
 	verbose bool
+	logger  StdLogger
 }
 
 func (o *testQueryObserver) ObserveQuery(ctx context.Context, q ObservedQuery) {
 	host := q.Host.ConnectAddress().String()
 	o.metrics[host] = q.Metrics
 	if o.verbose {
-		Logger.Printf("Observed query %q. Returned %v rows, took %v on host %q with %v attempts and total latency %v. Error: %q\n",
+		o.logger.Printf("Observed query %q. Returned %v rows, took %v on host %q with %v attempts and total latency %v. Error: %q\n",
 			q.Statement, q.Rows, q.End.Sub(q.Start), host, q.Metrics.Attempts, q.Metrics.TotalLatency, q.Err)
 	}
 }
@@ -383,9 +375,7 @@ func TestQueryRetry(t *testing.T) {
 
 func TestQueryMultinodeWithMetrics(t *testing.T) {
 	log := &testLogger{}
-	Logger = log
 	defer func() {
-		Logger = &defaultLogger{}
 		os.Stdout.WriteString(log.String())
 	}()
 
@@ -412,7 +402,7 @@ func TestQueryMultinodeWithMetrics(t *testing.T) {
 
 	// 1 retry per host
 	rt := &SimpleRetryPolicy{NumRetries: 3}
-	observer := &testQueryObserver{metrics: make(map[string]*hostMetrics), verbose: false}
+	observer := &testQueryObserver{metrics: make(map[string]*hostMetrics), verbose: false, logger: log}
 	qry := db.Query("kill").RetryPolicy(rt).Observer(observer)
 	if err := qry.Exec(); err == nil {
 		t.Fatalf("expected error")
@@ -460,9 +450,7 @@ func (t *testRetryPolicy) GetRetryType(err error) RetryType {
 
 func TestSpeculativeExecution(t *testing.T) {
 	log := &testLogger{}
-	Logger = log
 	defer func() {
-		Logger = &defaultLogger{}
 		os.Stdout.WriteString(log.String())
 	}()
 
@@ -692,6 +680,7 @@ func TestStream0(t *testing.T) {
 	conn := &Conn{
 		r:       bufio.NewReader(&buf),
 		streams: streams.New(protoVersion4),
+		logger:  &defaultLogger{},
 	}
 
 	err := conn.recv(context.Background())

--- a/control.go
+++ b/control.go
@@ -177,7 +177,7 @@ func (c *controlConn) shuffleDial(endpoints []*HostInfo) (*Conn, error) {
 			return conn, nil
 		}
 
-		Logger.Printf("gocql: unable to dial control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
+		c.session.logger.Printf("gocql: unable to dial control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
 	}
 
 	return nil, err
@@ -372,7 +372,7 @@ func (c *controlConn) reconnect(refreshring bool) {
 
 	if err := c.setupConn(newConn); err != nil {
 		newConn.Close()
-		Logger.Printf("gocql: control unable to register events: %v\n", err)
+		c.session.logger.Printf("gocql: control unable to register events: %v\n", err)
 		return
 	}
 
@@ -456,7 +456,7 @@ func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter
 		})
 
 		if gocqlDebug && iter.err != nil {
-			Logger.Printf("control: error executing %q: %v\n", statement, iter.err)
+			c.session.logger.Printf("control: error executing %q: %v\n", statement, iter.err)
 		}
 
 		q.AddAttempts(1, c.getConn().host)

--- a/events_test.go
+++ b/events_test.go
@@ -15,7 +15,7 @@ func TestEventDebounce(t *testing.T) {
 	debouncer := newEventDebouncer("testDebouncer", func(events []frame) {
 		defer wg.Done()
 		eventsSeen += len(events)
-	})
+	}, &defaultLogger{})
 	defer debouncer.stop()
 
 	for i := 0; i < eventCount; i++ {

--- a/filters.go
+++ b/filters.go
@@ -40,7 +40,7 @@ func DataCentreHostFilter(dataCentre string) HostFilter {
 // WhiteListHostFilter filters incoming hosts by checking that their address is
 // in the initial hosts whitelist.
 func WhiteListHostFilter(hosts ...string) HostFilter {
-	hostInfos, err := addrsToHosts(hosts, 9042)
+	hostInfos, err := addrsToHosts(hosts, 9042, nopLogger{})
 	if err != nil {
 		// dont want to panic here, but rather not break the API
 		panic(fmt.Errorf("unable to lookup host info from address: %v", err))

--- a/frame.go
+++ b/frame.go
@@ -400,14 +400,14 @@ func newFramer(compressor Compressor, version byte) *framer {
 	return f
 }
 
-func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlProtocolExtension) *framer {
+func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlProtocolExtension, logger StdLogger) *framer {
 
 	f := newFramer(compressor, version)
 
 	if lwtExt := findCQLProtoExtByName(cqlProtoExts, lwtAddMetadataMarkKey); lwtExt != nil {
 		castedExt, ok := lwtExt.(*lwtAddMetadataMarkExt)
 		if !ok {
-			Logger.Println(
+			logger.Println(
 				fmt.Errorf("Failed to cast CQL protocol extension identified by name %s to type %T",
 					lwtAddMetadataMarkKey, lwtAddMetadataMarkExt{}))
 			return f

--- a/helpers.go
+++ b/helpers.go
@@ -130,38 +130,38 @@ func getCassandraBaseType(name string) Type {
 	}
 }
 
-func getCassandraType(name string) TypeInfo {
+func getCassandraType(name string, logger StdLogger) TypeInfo {
 	if strings.HasPrefix(name, "frozen<") {
-		return getCassandraType(strings.TrimPrefix(name[:len(name)-1], "frozen<"))
+		return getCassandraType(strings.TrimPrefix(name[:len(name)-1], "frozen<"), logger)
 	} else if strings.HasPrefix(name, "set<") {
 		return CollectionType{
 			NativeType: NativeType{typ: TypeSet},
-			Elem:       getCassandraType(strings.TrimPrefix(name[:len(name)-1], "set<")),
+			Elem:       getCassandraType(strings.TrimPrefix(name[:len(name)-1], "set<"), logger),
 		}
 	} else if strings.HasPrefix(name, "list<") {
 		return CollectionType{
 			NativeType: NativeType{typ: TypeList},
-			Elem:       getCassandraType(strings.TrimPrefix(name[:len(name)-1], "list<")),
+			Elem:       getCassandraType(strings.TrimPrefix(name[:len(name)-1], "list<"), logger),
 		}
 	} else if strings.HasPrefix(name, "map<") {
 		names := splitCompositeTypes(strings.TrimPrefix(name[:len(name)-1], "map<"))
 		if len(names) != 2 {
-			Logger.Printf("Error parsing map type, it has %d subelements, expecting 2\n", len(names))
+			logger.Printf("Error parsing map type, it has %d subelements, expecting 2\n", len(names))
 			return NativeType{
 				typ: TypeCustom,
 			}
 		}
 		return CollectionType{
 			NativeType: NativeType{typ: TypeMap},
-			Key:        getCassandraType(names[0]),
-			Elem:       getCassandraType(names[1]),
+			Key:        getCassandraType(names[0], logger),
+			Elem:       getCassandraType(names[1], logger),
 		}
 	} else if strings.HasPrefix(name, "tuple<") {
 		names := splitCompositeTypes(strings.TrimPrefix(name[:len(name)-1], "tuple<"))
 		types := make([]TypeInfo, len(names))
 
 		for i, name := range names {
-			types[i] = getCassandraType(name)
+			types[i] = getCassandraType(name, logger)
 		}
 
 		return TupleTypeInfo{

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGetCassandraType_Set(t *testing.T) {
-	typ := getCassandraType("set<text>")
+	typ := getCassandraType("set<text>", &defaultLogger{})
 	set, ok := typ.(CollectionType)
 	if !ok {
 		t.Fatalf("expected CollectionType got %T", typ)
@@ -203,7 +203,7 @@ func TestGetCassandraType(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
-			got := getCassandraType(test.input)
+			got := getCassandraType(test.input, &defaultLogger{})
 
 			// TODO(zariel): define an equal method on the types?
 			if !reflect.DeepEqual(got, test.exp) {

--- a/host_source.go
+++ b/host_source.go
@@ -560,7 +560,7 @@ func (r *ringDescriber) getClusterPeerInfo() ([]*HostInfo, error) {
 			return nil, err
 		} else if !isValidPeer(host) {
 			// If it's not a valid peer
-			Logger.Printf("Found invalid peer '%s' "+
+			r.session.logger.Printf("Found invalid peer '%s' "+
 				"Likely due to a gossip or snitch issue, this host will be ignored", host)
 			continue
 		}

--- a/logger.go
+++ b/logger.go
@@ -12,6 +12,14 @@ type StdLogger interface {
 	Println(v ...interface{})
 }
 
+type nopLogger struct{}
+
+func (n nopLogger) Print(_ ...interface{}) {}
+
+func (n nopLogger) Printf(_ string, _ ...interface{}) {}
+
+func (n nopLogger) Println(_ ...interface{}) {}
+
 type testLogger struct {
 	capture bytes.Buffer
 }
@@ -27,4 +35,6 @@ func (l *defaultLogger) Print(v ...interface{})                 { log.Print(v...
 func (l *defaultLogger) Printf(format string, v ...interface{}) { log.Printf(format, v...) }
 func (l *defaultLogger) Println(v ...interface{})               { log.Println(v...) }
 
+// Logger for logging messages.
+// Deprecated: Use ClusterConfig.Logger instead.
 var Logger StdLogger = &defaultLogger{}

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -567,11 +567,11 @@ func getColumnMetadata(session *Session, keyspaceName string) ([]ColumnMetadata,
 	return columns, nil
 }
 
-func getTypeInfo(t string) TypeInfo {
+func getTypeInfo(t string, logger StdLogger) TypeInfo {
 	if strings.HasPrefix(t, apacheCassandraTypePrefix) {
 		t = apacheToCassandraType(t)
 	}
-	return getCassandraType(t)
+	return getCassandraType(t, logger)
 }
 
 // query for type metadata in the system_schema.types

--- a/scylla.go
+++ b/scylla.go
@@ -69,7 +69,7 @@ var _ cqlProtocolExtension = &lwtAddMetadataMarkExt{}
 
 // Factory function to deserialize and create an `lwtAddMetadataMarkExt` instance
 // from SUPPORTED message payload.
-func newLwtAddMetaMarkExt(supported map[string][]string) *lwtAddMetadataMarkExt {
+func newLwtAddMetaMarkExt(supported map[string][]string, logger StdLogger) *lwtAddMetadataMarkExt {
 	const lwtOptMetaBitMaskKey = "LWT_OPTIMIZATION_META_BIT_MASK"
 
 	if v, found := supported[lwtAddMetadataMarkKey]; found {
@@ -82,7 +82,7 @@ func newLwtAddMetaMarkExt(supported map[string][]string) *lwtAddMetadataMarkExt 
 				)
 				if bitMask, err = strconv.Atoi(splitVal[1]); err != nil {
 					if gocqlDebug {
-						Logger.Printf("scylla: failed to parse %s value %v: %s", lwtOptMetaBitMaskKey, splitVal[1], err)
+						logger.Printf("scylla: failed to parse %s value %v: %s", lwtOptMetaBitMaskKey, splitVal[1], err)
 						return nil
 					}
 				}
@@ -105,7 +105,7 @@ func (ext *lwtAddMetadataMarkExt) name() string {
 	return lwtAddMetadataMarkKey
 }
 
-func parseSupported(supported map[string][]string) scyllaSupported {
+func parseSupported(supported map[string][]string, logger StdLogger) scyllaSupported {
 	const (
 		scyllaShard             = "SCYLLA_SHARD"
 		scyllaNrShards          = "SCYLLA_NR_SHARDS"
@@ -124,21 +124,21 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 	if s, ok := supported[scyllaShard]; ok {
 		if si.shard, err = strconv.Atoi(s[0]); err != nil {
 			if gocqlDebug {
-				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShard, s, err)
+				logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShard, s, err)
 			}
 		}
 	}
 	if s, ok := supported[scyllaNrShards]; ok {
 		if si.nrShards, err = strconv.Atoi(s[0]); err != nil {
 			if gocqlDebug {
-				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaNrShards, s, err)
+				logger.Printf("scylla: failed to parse %s value %v: %s", scyllaNrShards, s, err)
 			}
 		}
 	}
 	if s, ok := supported[scyllaShardingIgnoreMSB]; ok {
 		if si.msbIgnore, err = strconv.ParseUint(s[0], 10, 64); err != nil {
 			if gocqlDebug {
-				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardingIgnoreMSB, s, err)
+				logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardingIgnoreMSB, s, err)
 			}
 		}
 	}
@@ -152,7 +152,7 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 	if s, ok := supported[scyllaShardAwarePort]; ok {
 		if shardAwarePort, err := strconv.ParseUint(s[0], 10, 16); err != nil {
 			if gocqlDebug {
-				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardAwarePort, s, err)
+				logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardAwarePort, s, err)
 			}
 		} else {
 			si.shardAwarePort = uint16(shardAwarePort)
@@ -161,7 +161,7 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 	if s, ok := supported[scyllaShardAwarePortSSL]; ok {
 		if shardAwarePortSSL, err := strconv.ParseUint(s[0], 10, 16); err != nil {
 			if gocqlDebug {
-				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardAwarePortSSL, s, err)
+				logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardAwarePortSSL, s, err)
 			}
 		} else {
 			si.shardAwarePortSSL = uint16(shardAwarePortSSL)
@@ -170,7 +170,7 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 
 	if si.partitioner != "org.apache.cassandra.dht.Murmur3Partitioner" || si.shardingAlgorithm != "biased-token-round-robin" || si.nrShards == 0 || si.msbIgnore == 0 {
 		if gocqlDebug {
-			Logger.Printf("scylla: unsupported sharding configuration, partitioner=%s, algorithm=%s, no_shards=%d, msb_ignore=%d",
+			logger.Printf("scylla: unsupported sharding configuration, partitioner=%s, algorithm=%s, no_shards=%d, msb_ignore=%d",
 				si.partitioner, si.shardingAlgorithm, si.nrShards, si.msbIgnore)
 		}
 		return scyllaSupported{}
@@ -179,10 +179,10 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 	return si
 }
 
-func parseCQLProtocolExtensions(supported map[string][]string) []cqlProtocolExtension {
+func parseCQLProtocolExtensions(supported map[string][]string, logger StdLogger) []cqlProtocolExtension {
 	exts := []cqlProtocolExtension{}
 
-	lwtExt := newLwtAddMetaMarkExt(supported)
+	lwtExt := newLwtAddMetaMarkExt(supported, logger)
 	if lwtExt != nil {
 		exts = append(exts, lwtExt)
 	}
@@ -222,6 +222,8 @@ type scyllaConnPicker struct {
 
 	// Used to disable new connections to the shard-aware port temporarily
 	disableShardAwarePortUntil *atomic.Value
+
+	logger StdLogger
 }
 
 func newScyllaConnPicker(conn *Conn) *scyllaConnPicker {
@@ -232,7 +234,7 @@ func newScyllaConnPicker(conn *Conn) *scyllaConnPicker {
 	}
 
 	if gocqlDebug {
-		Logger.Printf("scylla: %s new conn picker sharding options %+v", addr, conn.scyllaSupported)
+		conn.logger.Printf("scylla: %s new conn picker sharding options %+v", addr, conn.scyllaSupported)
 	}
 
 	var shardAwarePort uint16
@@ -258,6 +260,8 @@ func newScyllaConnPicker(conn *Conn) *scyllaConnPicker {
 		shardAwarePortDisabled: conn.session.cfg.DisableShardAwarePort,
 
 		disableShardAwarePortUntil: new(atomic.Value),
+
+		logger: conn.logger,
 	}
 }
 
@@ -348,7 +352,7 @@ func (p *scyllaConnPicker) Put(conn *Conn) {
 			// changes the source port along the way, therefore we can't trust
 			// the shard-aware port to return connection to the shard
 			// that we requested. Fall back to non-shard-aware port for some time.
-			Logger.Printf(
+			p.logger.Printf(
 				"scylla: %s connection to shard-aware address %s resulted in wrong shard being assigned; please check that you are not behind a NAT or AddressTranslater which changes source ports; falling back to non-shard-aware port for %v",
 				p.address,
 				p.shardAwareAddress,
@@ -364,14 +368,14 @@ func (p *scyllaConnPicker) Put(conn *Conn) {
 		} else {
 			p.excessConns = append(p.excessConns, conn)
 			if gocqlDebug {
-				Logger.Printf("scylla: %s put shard %d excess connection total: %d missing: %d excess: %d", p.address, shard, p.nrConns, p.nrShards-p.nrConns, len(p.excessConns))
+				p.logger.Printf("scylla: %s put shard %d excess connection total: %d missing: %d excess: %d", p.address, shard, p.nrConns, p.nrShards-p.nrConns, len(p.excessConns))
 			}
 		}
 	} else {
 		p.conns[shard] = conn
 		p.nrConns++
 		if gocqlDebug {
-			Logger.Printf("scylla: %s put shard %d connection total: %d missing: %d", p.address, shard, p.nrConns, p.nrShards-p.nrConns)
+			p.logger.Printf("scylla: %s put shard %d connection total: %d missing: %d", p.address, shard, p.nrConns, p.nrShards-p.nrConns)
 		}
 	}
 
@@ -396,12 +400,12 @@ func (p *scyllaConnPicker) Remove(conn *Conn) {
 		// It is possible for Remove to be called before the connection is added to the pool.
 		// Ignoring these connections here is safe.
 		if gocqlDebug {
-			Logger.Printf("scylla: %s has unknown sharding state, ignoring it", p.address)
+			p.logger.Printf("scylla: %s has unknown sharding state, ignoring it", p.address)
 		}
 		return
 	}
 	if gocqlDebug {
-		Logger.Printf("scylla: %s remove shard %d connection", p.address, shard)
+		p.logger.Printf("scylla: %s remove shard %d connection", p.address, shard)
 	}
 
 	if p.conns[shard] != nil {
@@ -422,7 +426,7 @@ func (p *scyllaConnPicker) Close() {
 func (p *scyllaConnPicker) closeConns() {
 	if len(p.conns) == 0 {
 		if gocqlDebug {
-			Logger.Printf("scylla: %s no connections to close", p.address)
+			p.logger.Printf("scylla: %s no connections to close", p.address)
 		}
 		return
 	}
@@ -432,7 +436,7 @@ func (p *scyllaConnPicker) closeConns() {
 	p.nrConns = 0
 
 	if gocqlDebug {
-		Logger.Printf("scylla: %s closing %d connections", p.address, len(conns))
+		p.logger.Printf("scylla: %s closing %d connections", p.address, len(conns))
 	}
 	go closeConns(conns...)
 }
@@ -440,7 +444,7 @@ func (p *scyllaConnPicker) closeConns() {
 func (p *scyllaConnPicker) closeExcessConns() {
 	if len(p.excessConns) == 0 {
 		if gocqlDebug {
-			Logger.Printf("scylla: %s no excess connections to close", p.address)
+			p.logger.Printf("scylla: %s no excess connections to close", p.address)
 		}
 		return
 	}
@@ -449,7 +453,7 @@ func (p *scyllaConnPicker) closeExcessConns() {
 	p.excessConns = nil
 
 	if gocqlDebug {
-		Logger.Printf("scylla: %s closing %d excess connections", p.address, len(conns))
+		p.logger.Printf("scylla: %s closing %d excess connections", p.address, len(conns))
 	}
 	go closeConns(conns...)
 }
@@ -489,6 +493,7 @@ func (p *scyllaConnPicker) GetCustomDialer() Dialer {
 				shardID:           shardID,
 				nrShards:          p.nrShards,
 				dialer:            p.dialer,
+				logger:            p.logger,
 			}
 		}
 	}
@@ -504,6 +509,7 @@ type scyllaOneShardDialer struct {
 	shardID           int
 	nrShards          int
 	dialer            Dialer
+	logger            StdLogger
 }
 
 const scyllaShardAwarePortFallbackDuration time.Duration = 5 * time.Minute
@@ -512,7 +518,7 @@ func (sosd *scyllaOneShardDialer) DialContext(ctx context.Context, network, addr
 	iter := newScyllaPortIterator(sosd.shardID, sosd.nrShards)
 
 	if gocqlDebug {
-		Logger.Printf("scylla: connecting to shard %d", sosd.shardID)
+		sosd.logger.Printf("scylla: connecting to shard %d", sosd.shardID)
 	}
 
 	for {
@@ -540,7 +546,7 @@ func (sosd *scyllaOneShardDialer) DialContext(ctx context.Context, network, addr
 				// We can't avoid false positives here, so I'm putting it
 				// behind a debug flag.
 				if gocqlDebug {
-					Logger.Printf(
+					sosd.logger.Printf(
 						"scylla: %s couldn't connect to shard-aware address while the non-shard-aware address %s is available; this might be an issue with ",
 						addr,
 						sosd.shardAwareAddress,
@@ -659,7 +665,9 @@ func scyllaGetTablePartitioner(session *Session, keyspaceName, tableName string)
 		return nil, err
 	}
 	if isCdc {
-		return scyllaCDCPartitioner{}, nil
+		return scyllaCDCPartitioner{
+			logger: session.logger,
+		}, nil
 	}
 
 	return nil, nil

--- a/scylla_cdc.go
+++ b/scylla_cdc.go
@@ -22,7 +22,9 @@ const (
 	scyllaCDCExtensionName      = "cdc"
 )
 
-type scyllaCDCPartitioner struct{}
+type scyllaCDCPartitioner struct {
+	logger StdLogger
+}
 
 var _ partitioner = scyllaCDCPartitioner{}
 
@@ -35,7 +37,7 @@ func (p scyllaCDCPartitioner) Hash(partitionKey []byte) token {
 		// The key is too short to extract any sensible token,
 		// so return the min token instead
 		if gocqlDebug {
-			Logger.Printf("scylla: cdc partition key too short: %d < 8", len(partitionKey))
+			p.logger.Printf("scylla: cdc partition key too short: %d < 8", len(partitionKey))
 		}
 		return scyllaCDCMinToken
 	}
@@ -48,7 +50,7 @@ func (p scyllaCDCPartitioner) Hash(partitionKey []byte) token {
 		if len(partitionKey) != scyllaCDCPartitionKeyLength {
 			// The token has unrecognized format, but the first quadword
 			// should be the token value that we want
-			Logger.Printf("scylla: wrong size of cdc partition key: %d", len(partitionKey))
+			p.logger.Printf("scylla: wrong size of cdc partition key: %d", len(partitionKey))
 		}
 
 		lowerQword := binary.BigEndian.Uint64(partitionKey[8:])
@@ -56,7 +58,7 @@ func (p scyllaCDCPartitioner) Hash(partitionKey []byte) token {
 		if version < scyllaCDCMinSupportedVersion || version > scyllaCDCMaxSupportedVersion {
 			// We don't support this version yet,
 			// the token may be wrong
-			Logger.Printf(
+			p.logger.Printf(
 				"scylla: unsupported version: %d is not in range [%d, %d]",
 				version,
 				scyllaCDCMinSupportedVersion,

--- a/session_test.go
+++ b/session_test.go
@@ -16,6 +16,7 @@ func TestSessionAPI(t *testing.T) {
 		cfg:    *cfg,
 		cons:   Quorum,
 		policy: RoundRobinHostPolicy(),
+		logger: cfg.logger(),
 	}
 
 	s.pool = cfg.PoolConfig.buildPool(s)
@@ -194,8 +195,9 @@ func TestBatchBasicAPI(t *testing.T) {
 	cfg := &ClusterConfig{RetryPolicy: &SimpleRetryPolicy{NumRetries: 2}}
 
 	s := &Session{
-		cfg:  *cfg,
-		cons: Quorum,
+		cfg:    *cfg,
+		cons:   Quorum,
+		logger: cfg.logger(),
 	}
 	defer s.Close()
 

--- a/tokenawarelatency.go
+++ b/tokenawarelatency.go
@@ -346,7 +346,7 @@ func (t *TokenAwareLatencyHostPolicy) updateReplicasLoop(ks *tokenAwareLatencyKe
 			continue
 		}
 
-		strategy := getStrategy(metadata)
+		strategy := getStrategy(metadata, t.logger)
 		var replicas tokenRingReplicas
 
 		if strategy != nil {

--- a/topology.go
+++ b/topology.go
@@ -66,12 +66,12 @@ func getReplicationFactorFromOpts(val interface{}) (int, error) {
 	}
 }
 
-func getStrategy(ks *KeyspaceMetadata) placementStrategy {
+func getStrategy(ks *KeyspaceMetadata, logger StdLogger) placementStrategy {
 	switch {
 	case strings.Contains(ks.StrategyClass, "SimpleStrategy"):
 		rf, err := getReplicationFactorFromOpts(ks.StrategyOptions["replication_factor"])
 		if err != nil {
-			Logger.Printf("parse rf for keyspace %q: %v", ks.Name, err)
+			logger.Printf("parse rf for keyspace %q: %v", ks.Name, err)
 			return nil
 		}
 		return &simpleStrategy{rf: rf}
@@ -84,7 +84,7 @@ func getStrategy(ks *KeyspaceMetadata) placementStrategy {
 
 			rf, err := getReplicationFactorFromOpts(rf)
 			if err != nil {
-				Logger.Println("parse rf for keyspace %q, dc %q: %v", err)
+				logger.Println("parse rf for keyspace %q, dc %q: %v", err)
 				// skip DC if the rf is invalid/unsupported, so that we can at least work with other working DCs.
 				continue
 			}
@@ -95,7 +95,7 @@ func getStrategy(ks *KeyspaceMetadata) placementStrategy {
 	case strings.Contains(ks.StrategyClass, "LocalStrategy"):
 		return nil
 	default:
-		Logger.Printf("parse rf for keyspace %q: unsupported strategy class: %v", ks.StrategyClass)
+		logger.Printf("parse rf for keyspace %q: unsupported strategy class: %v", ks.StrategyClass)
 		return nil
 	}
 }


### PR DESCRIPTION
There are race conditions in tests that swap the global logger,
we shouldn't modify any global state in tests or otherwise.