### PR TITLE
Skip TestTokenAwareConnPool

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -2079,6 +2079,7 @@ func TestRoutingKey(t *testing.T) {
 
 // Integration test of the token-aware policy-based connection pool
 func TestTokenAwareConnPool(t *testing.T) {
+	t.Skip("flaky test, sometimes works, sometimes doesn't")
 	cluster := createCluster()
 	cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(RoundRobinHostPolicy())
 


### PR DESCRIPTION
This test only works with Cassandra, not Scylla because of different
ConnPool implementation. The test is also missing verification that
the query went to the correct host, so it's of questionable value.
We run tests against Scylla, so removing the test to fix CI.

Skipping the test instead of removing to keep diff between our fork
and upstream smaller.