### PR TITLE
Fix deadlock in closeWithError

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1094,6 +1094,10 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*fram
 		return nil, err
 	}
 
+	// After this point, we need to either read from call.resp or close(call.timeout)
+	// since closeWithError can try to write a connection close error to call.resp.
+	// If we don't close(call.timeout) or read from call.resp, closeWithError can deadlock.
+
 	if tracer != nil {
 		framer.trace()
 	}
@@ -1106,6 +1110,9 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*fram
 
 	err := req.buildFrame(framer, stream)
 	if err != nil {
+		// closeWithError will block waiting for this stream to either receive a response
+		// or for us to timeout.
+		close(call.timeout)
 		// We failed to serialize the frame into a buffer.
 		// This should not affect the connection as we didn't write anything. We just free the current call.
 		c.mu.Lock()
@@ -1121,6 +1128,10 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*fram
 
 	n, err := c.w.writeContext(ctx, framer.buf)
 	if err != nil {
+		// closeWithError will block waiting for this stream to either receive a response
+		// or for us to timeout, close the timeout chan here. Im not entirely sure
+		// but we should not get a response after an error on the write side.
+		close(call.timeout)
 		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && n == 0 {
 			// We have not started to write this frame.
 			// Release the stream as no response can come from the server on the stream.
@@ -1133,10 +1144,6 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*fram
 			// check above could fail.
 			c.releaseStream(call)
 		} else {
-			// closeWithError will block waiting for this stream to either receive a response
-			// or for us to timeout, close the timeout chan here. Im not entirely sure
-			// but we should not get a response after an error on the write side.
-			close(call.timeout)
 			// I think this is the correct thing to do, im not entirely sure. It is not
 			// ideal as readers might still get some data, but they probably wont.
 			// Here we need to be careful as the stream is not available and if all
@@ -1204,6 +1211,7 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*fram
 		close(call.timeout)
 		return nil, ctx.Err()
 	case <-c.ctx.Done():
+		close(call.timeout)
 		return nil, ErrConnectionClosed
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -173,7 +173,10 @@ type Conn struct {
 
 	streams *streams.IDGenerator
 	mu      sync.Mutex
-	calls   map[int]*callReq
+	// calls stores a map from stream ID to callReq.
+	// This map is protected by mu.
+	// calls should not be used when closed is true, calls is set to nil when closed=true.
+	calls map[int]*callReq
 
 	errorHandler ConnErrorHandler
 	compressor   Compressor
@@ -189,7 +192,9 @@ type Conn struct {
 
 	session *Session
 
-	closed int32
+	// true if connection close process for the connection started.
+	// closed is protected by mu.
+	closed bool
 	ctx    context.Context
 	cancel context.CancelFunc
 
@@ -555,30 +560,38 @@ func (c *Conn) closeWithError(err error) {
 		return
 	}
 
-	if !atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
 		return
 	}
+	c.closed = true
 
-	// we should attempt to deliver the error back to the caller if it
-	// exists
+	var callsToClose map[int]*callReq
+
+	// We should attempt to deliver the error back to the caller if it
+	// exists. However, don't block c.mu while we are delivering the
+	// error to outstanding calls.
 	if err != nil {
-		c.mu.Lock()
-		for _, req := range c.calls {
-			// we need to send the error to all waiting queries, put the state
-			// of this conn into not active so that it can not execute any queries.
-			select {
-			case req.resp <- callResp{err: err}:
-			case <-req.timeout:
-			}
-			if req.streamObserverContext != nil {
-				req.streamObserverEndOnce.Do(func() {
-					req.streamObserverContext.StreamAbandoned(ObservedStream{
-						Host: c.host,
-					})
-				})
-			}
+		callsToClose = c.calls
+		// It is safe to change c.calls to nil. Nobody should use it after c.closed is set to true.
+		c.calls = nil
+	}
+	c.mu.Unlock()
+
+	for _, req := range callsToClose {
+		// we need to send the error to all waiting queries.
+		select {
+		case req.resp <- callResp{err: err}:
+		case <-req.timeout:
 		}
-		c.mu.Unlock()
+		if req.streamObserverContext != nil {
+			req.streamObserverEndOnce.Do(func() {
+				req.streamObserverContext.StreamAbandoned(ObservedStream{
+					Host: c.host,
+				})
+			})
+		}
 	}
 
 	// if error was nil then unblock the quit channel
@@ -745,6 +758,10 @@ func (c *Conn) recv(ctx context.Context) error {
 	}
 
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return ErrConnectionClosed
+	}
 	call, ok := c.calls[head.stream]
 	delete(c.calls, head.stream)
 	c.mu.Unlock()
@@ -1031,6 +1048,24 @@ func (w *writeCoalescer) flush(resultChans []chan<- writeResult, buffers net.Buf
 	}
 }
 
+// addCall attempts to add a call to c.calls.
+// It fails with error if the connection already started closing or if a call for the given stream
+// already exists.
+func (c *Conn) addCall(call *callReq) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return ErrConnectionClosed
+	}
+	existingCall := c.calls[call.streamID]
+	if existingCall != nil {
+		return fmt.Errorf("attempting to use stream already in use: %d -> %d", call.streamID,
+			existingCall.streamID)
+	}
+	c.calls[call.streamID] = call
+	return nil
+}
+
 func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*framer, error) {
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
@@ -1055,15 +1090,8 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*fram
 		call.streamObserverContext = c.streamObserver.StreamContext(ctx)
 	}
 
-	c.mu.Lock()
-	existingCall := c.calls[stream]
-	if existingCall == nil {
-		c.calls[stream] = call
-	}
-	c.mu.Unlock()
-
-	if existingCall != nil {
-		return nil, fmt.Errorf("attempting to use stream already in use: %d -> %d", stream, existingCall.streamID)
+	if err := c.addCall(call); err != nil {
+		return nil, err
 	}
 
 	if tracer != nil {
@@ -1081,7 +1109,9 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*fram
 		// We failed to serialize the frame into a buffer.
 		// This should not affect the connection as we didn't write anything. We just free the current call.
 		c.mu.Lock()
-		delete(c.calls, call.streamID)
+		if !c.closed {
+			delete(c.calls, call.streamID)
+		}
 		c.mu.Unlock()
 		// We need to release the stream after we remove the call from c.calls, otherwise the existingCall != nil
 		// check above could fail.
@@ -1095,7 +1125,9 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*fram
 			// We have not started to write this frame.
 			// Release the stream as no response can come from the server on the stream.
 			c.mu.Lock()
-			delete(c.calls, call.streamID)
+			if !c.closed {
+				delete(c.calls, call.streamID)
+			}
 			c.mu.Unlock()
 			// We need to release the stream after we remove the call from c.calls, otherwise the existingCall != nil
 			// check above could fail.
@@ -1497,7 +1529,9 @@ func (c *Conn) Pick(qry *Query) *Conn {
 }
 
 func (c *Conn) Closed() bool {
-	return atomic.LoadInt32(&c.closed) == 1
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
 }
 
 func (c *Conn) Address() string {


### PR DESCRIPTION
Only the second commit is strictly necessary, the first commit makes it a little clearer who owns what during connection closing.