### PR TITLE
Don't call t.Fatalf in non-test goroutines

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -303,7 +303,8 @@ func TestCancel(t *testing.T) {
 
 	go func() {
 		if err := qry.Exec(); err != context.Canceled {
-			t.Fatalf("expected to get context cancel error: '%v', got '%v'", context.Canceled, err)
+			t.Logf("expected to get context cancel error: '%v', got '%v'", context.Canceled, err)
+			t.Fail()
 		}
 		wg.Done()
 	}()

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -189,7 +189,8 @@ func pickLoop(t *testing.T, s *scyllaConnPicker, c int, wg *sync.WaitGroup) {
 	t.Helper()
 	for i := 0; i < c; i++ {
 		if s.Pick(token(nil)) == nil {
-			t.Fatal("expected connection")
+			t.Log("expected connection")
+			t.Fail()
 		}
 	}
 	wg.Done()


### PR DESCRIPTION
Calling Fatalf does not stop the test and can create deadlock
because wg.Done would never be called.

Let's call Log+Fail instead.

This was flagged by go vet.