### PR TITLE
Add configurable MaxRequestsPerConn cluster param

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -74,6 +74,11 @@ type ClusterConfig struct {
 	// Default: 2
 	NumConns int
 
+	// Maximum number of inflight requests allowed per connection.
+	// Default: 32768 for CQL v3 and newer
+	// Default: 128 for older CQL versions
+	MaxRequestsPerConn int
+
 	// Default consistency level.
 	// Default: Quorum
 	Consistency Consistency

--- a/conn.go
+++ b/conn.go
@@ -287,7 +287,7 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 		errorHandler:  errorHandler,
 		compressor:    cfg.Compressor,
 		session:       s,
-		streams:       streams.New(cfg.ProtoVersion),
+		streams:       streams.NewLimited(cfg.ProtoVersion, s.cfg.MaxRequestsPerConn),
 		host:          host,
 		isSchemaV2:    true, // Try using "system.peers_v2" until proven otherwise
 		frameObserver: s.frameObserver,
@@ -716,7 +716,7 @@ func (c *Conn) recv(ctx context.Context) error {
 		})
 	}
 
-	if head.stream > c.streams.NumStreams {
+	if head.stream > c.streams.MaxStreamID {
 		return fmt.Errorf("gocql: frame header stream is beyond call expected bounds: %d", head.stream)
 	} else if head.stream == -1 {
 		// TODO: handle cassandra event frames, we shouldnt get any currently

--- a/internal/streams/streams_test.go
+++ b/internal/streams/streams_test.go
@@ -58,6 +58,31 @@ func TestFullStreams(t *testing.T) {
 	}
 }
 
+func TestFullStreamsLimited(t *testing.T) {
+	max := 20
+	streams := NewLimited(3, max)
+
+	if got := streams.Available(); got != max {
+		t.Fatalf("available should reflect the number of streams, expected %d, got %d", max, got)
+	}
+
+	for i := 0; i < max; i++ {
+		stream, ok := streams.GetStream()
+		if !ok {
+			t.Fatalf("should get stream when not all in use: stream=%d", stream)
+		}
+	}
+
+	stream, ok := streams.GetStream()
+	if ok {
+		t.Fatalf("should not get stream when all in use: stream=%d", stream)
+	}
+
+	if got := streams.Available(); got != 0 {
+		t.Fatalf("available should reflect the number of streams, expected zero, got %d", got)
+	}
+}
+
 func TestClearStreams(t *testing.T) {
 	streams := New(1)
 	for i := range streams.streams {


### PR DESCRIPTION
Before this change, a connection had a hardcoded maximum number of streams. Since this value was so large (32768 for CQL v3+) this essentially meant an unbound concurrency.

This commit allows a user to configure this parameter by a newly added MaxRequestsPerConn option.

The "MaxRequestsPerConn" naming was chosen to be very general deliberately to allow us to safely introduce a more advanced behavior in the future: where the concurrency limiting happens not at a IDGenerator level and an additional client-side queue is introduced for requests to wait to be sent to Scylla (in addition to inflight requests).

This commit deliberately does not change the defaults as to be non-pessimizing for the users.