### PR TITLE
Expose query/batch consistency in observers

### DIFF
--- a/session.go
+++ b/session.go
@@ -1119,18 +1119,20 @@ func (q *Query) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 		scyllaToken, _ := token.(int64Token)
 
 		q.observer.ObserveQuery(q.Context(), ObservedQuery{
-			Keyspace:    keyspace,
-			Statement:   q.stmt,
-			Values:      q.values,
-			Start:       start,
-			End:         end,
-			Rows:        iter.numRows,
-			Host:        host,
-			ScyllaShard: shard,
-			ScyllaToken: int64(scyllaToken),
-			Metrics:     metricsForHost,
-			Err:         iter.err,
-			Attempt:     attempt,
+			Keyspace:          keyspace,
+			Statement:         q.stmt,
+			Values:            q.values,
+			Start:             start,
+			End:               end,
+			Rows:              iter.numRows,
+			Host:              host,
+			ScyllaShard:       shard,
+			ScyllaToken:       int64(scyllaToken),
+			Metrics:           metricsForHost,
+			Err:               iter.err,
+			Attempt:           attempt,
+			Consistency:       q.cons,
+			SerialConsistency: q.serialCons,
 		})
 	}
 }
@@ -1959,12 +1961,14 @@ func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 		Start:      start,
 		End:        end,
 		// Rows not used in batch observations // TODO - might be able to support it when using BatchCAS
-		Host:        host,
-		ScyllaShard: shard,
-		ScyllaToken: int64(scyllaToken),
-		Metrics:     metricsForHost,
-		Err:         iter.err,
-		Attempt:     attempt,
+		Host:              host,
+		ScyllaShard:       shard,
+		ScyllaToken:       int64(scyllaToken),
+		Metrics:           metricsForHost,
+		Err:               iter.err,
+		Attempt:           attempt,
+		Consistency:       b.Cons,
+		SerialConsistency: b.serialCons,
 	})
 }
 
@@ -2200,6 +2204,12 @@ type ObservedQuery struct {
 	// Attempt is the index of attempt at executing this query.
 	// The first attempt is number zero and any retries have non-zero attempt number.
 	Attempt int
+
+	// Consistency level of the query.
+	Consistency Consistency
+
+	// SerialConsistency level of the query.
+	SerialConsistency SerialConsistency
 }
 
 // QueryObserver is the interface implemented by query observers / stat collectors.
@@ -2243,6 +2253,12 @@ type ObservedBatch struct {
 	// Attempt is the index of attempt at executing this query.
 	// The first attempt is number zero and any retries have non-zero attempt number.
 	Attempt int
+
+	// Consistency of the batch.
+	Consistency Consistency
+
+	// SerialConsistency of the batch.
+	SerialConsistency SerialConsistency
 }
 
 // BatchObserver is the interface implemented by batch observers / stat collectors.


### PR DESCRIPTION
We want to track consistency of the queries.