### PR TITLE
Handle missing values when building a routing key

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -573,6 +573,7 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 
 	routingKey, err := qry.GetRoutingKey()
 	if err != nil {
+		t.logger.Printf("unable to get routing key for query: %v", err)
 		return t.fallback.Pick(qry)
 	} else if routingKey == nil {
 		return t.fallback.Pick(qry)


### PR DESCRIPTION
This fixes the following panic when not enough bound values are present:

```
panic: runtime error: index out of range [0] with length 0
goroutine 663 [running]:
github.com/gocql/gocql.createRoutingKey(0xc0004b4000, {0x0, 0x0, 0xc000042360?})
	/go/pkg/mod/github.com/kiwicom/gocql@v1.20.0/session.go:2097 +0x58d
github.com/gocql/gocql.(*Query).GetRoutingKey(0xc00089e8c0)
	/go/pkg/mod/github.com/kiwicom/gocql@v1.20.0/session.go:1231 +0x446
github.com/gocql/gocql.(*tokenAwareHostPolicy).Pick(0xc0000f2380, {0x195da60, 0xc00089e8c0})
	/go/pkg/mod/github.com/kiwicom/gocql@v1.20.0/policies.go:574 +0x64
github.com/gocql/gocql.(*queryExecutor).executeQuery(0xc000a12060, {0x195da60, 0xc00089e8c0})
	/go/pkg/mod/github.com/kiwicom/gocql@v1.20.0/query_executor.go:67 +0x96
github.com/gocql/gocql.(*Session).executeQuery(0xc00051fb00, 0x3?)
	/go/pkg/mod/github.com/kiwicom/gocql@v1.20.0/session.go:548 +0x145
github.com/gocql/gocql.(*Query).Iter(0xc00089e8c0)
	/go/pkg/mod/github.com/kiwicom/gocql@v1.20.0/session.go:1372 +0x13f
github.com/scylladb/gocqlx/v2.(*Queryx).Iter(...)
	/go/pkg/mod/github.com/scylladb/gocqlx/v2@v2.8.0/queryx.go:344
```